### PR TITLE
fix(gnss_launch): remove gnss_frame arg

### DIFF
--- a/sample_sensor_kit_launch/launch/gnss.launch.xml
+++ b/sample_sensor_kit_launch/launch/gnss.launch.xml
@@ -36,8 +36,6 @@
 
       <arg name="coordinate_system" value="$(var coordinate_system)"/>
       <arg name="use_ublox_receiver" value="true"/>
-
-      <arg name="gnss_frame" value="gnss_link"/>
     </include>
   </group>
 </launch>


### PR DESCRIPTION
## Description

I removed `gnss_frame` arg.

gnns_poser refers to `msg.header.frame_id` instead of parameter `gnss_frame`.
Please see https://github.com/autowarefoundation/autoware.universe/pull/6116

(The original reason why we can not pass `gnss_frame` as arg is https://github.com/autowarefoundation/autoware.universe/pull/5140 )

[TIER IV INTERNAL ANNOUNCEMENT LINK](https://star4.slack.com/archives/C4P0NSMB5/p1705640076668249)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
